### PR TITLE
Merging workspaces and control .dir path

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,6 +3,7 @@
 ^README\.Rmd$
 ^\.Rproj\.user$
 ^\.github$
+^\.lintr$
 ^\.pre-commit-config\.yaml$
 ^_pkgdown\.yml$
 ^codecov\.yml$
@@ -11,3 +12,4 @@
 ^pkgdown$
 ^workspace\.Rproj$
 _workspace
+dev

--- a/.github/workflows/validatoR.yml
+++ b/.github/workflows/validatoR.yml
@@ -1,0 +1,39 @@
+---
+name: R Package Validation report
+
+on: # Run this action when a release is published
+  release:
+    types: [published]
+
+jobs:
+  r-pkg-validation:
+    name: Create report 📃
+    runs-on: ubuntu-latest
+    container:
+      image: rocker/verse:4.1.1
+    # Set Github token permissions
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      packages: write
+      deployments: write
+    steps:
+      - name: Checkout repo 🛎
+        uses: actions/checkout@v3
+
+      - name: Build report 🏗
+        id: validation
+        uses: insightsengineering/thevalidatoR@main
+        # see parameters above for custom templates and other formats
+
+      # Upload the validation report to the release
+      - name: Upload report to release 🔼
+        if: success()
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: ${{ steps.validation.outputs.report_output_filename }}
+          asset_name: ${{ steps.validation.outputs.report_output_filename }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          overwrite: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: workspace
 Title: Effortlessly Create and Restore Development Environments
-Version: 0.1.0.9000
+Version: 0.1.1
 Authors@R:
     person("Kyle", "Harris", , "koderkow@gmail.com", role = c("aut", "cre", "cph"))
 Description: The {workspace} package aims to provide a seamless experience

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,11 +15,11 @@ URL: https://github.com/KoderKow/workspace,
 BugReports: https://github.com/KoderKow/workspace/issues
 Imports:
     qs,
-    utils
+    utils,
+    withr
 Suggests:
     covr,
-    testthat (>= 3.0.0),
-    withr
+    testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# workspace (development version)
+# workspace 0.1.1
 
 ## Enhancement
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 - Enhanced the restore confirmation message to display detailed information about the desired file [#1](https://github.com/KoderKow/workspace/issues/1)
   - Refactored portions of the code within `workspace_restore()` for modularity
   - Implemented unit tests for the refactored code
+- Added a parameter to `workspace_save()` to control where workspace files are saved [#5](https://github.com/KoderKow/workspace/issues/5)
+- Added an option while restoring to merge the current workspace with another file's workspace [#9](https://github.com/KoderKow/workspace/issues/9)
+- Improved user prompts to show that their environment will be cleared out while restoring
 
 ## Feature
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,7 +7,7 @@ red_x <- "\033[31mx\033[39m"
 last_hypen_pattern <- "-(?![^-]*-)"
 
 # Create file names
-generate_file_name <- function(note = "") {
+generate_file_name <- function(note = "", .dir = "_workspace") {
   file_name_init <- gsub(
     x = as.character(Sys.time()),
     pattern = " |:",
@@ -15,7 +15,7 @@ generate_file_name <- function(note = "") {
     perl = TRUE
   )
 
-  file_name <- paste0("_workspace/ws-", file_name_init, "_", note, ".qs")
+  file_name <- paste0(.dir, "/ws-", file_name_init, "_", note, ".qs")
 
   return(file_name)
 }

--- a/R/workspace_restore.R
+++ b/R/workspace_restore.R
@@ -24,6 +24,25 @@
 #'     - Upon confirming, it restores the workspace to the chosen restore point
 #'     and displays a "Restore complete" message
 #'
+#' # Restore method
+#'
+#' There are two ways to restore the environment
+#'
+#' 1. **Clear**
+#'     - Wipe the environment clean and restore the workspace from the wanted
+#'     file
+#'     - This option is best if you want to reproduce the wanted environment
+#'     when it was saved
+#' 2. **Merge**
+#'     - Combines the current environment/workspace with the wanted file
+#'     - There are two merge styles
+#'         - 1: **Current environment**: When bringing in the workspace from the
+#'          wanted file, it will prioritize the current environments variables
+#'          if the same variable is used in both environments
+#'         - 2: **Restore point**: When bringing in the workspace from the
+#'         wanted file, it will prioritize the restore file's variables if the
+#'         same variable is used in both environments
+#'
 #' @inheritParams workspace_save
 #' @family workspace functions
 #'
@@ -71,7 +90,8 @@ workspace_restore <- function(
 
   if (user_clear_or_merge == "Clear") {
     cat2(
-      "WARNING! Restoring will reset your global environment to '",
+      "WARNING! Restoring will clear out your current environment and reset your
+      global environment to '",
       r$files_display[r$i],
       "'. Continue?",
       symbol = red_todo
@@ -92,10 +112,10 @@ workspace_restore <- function(
     to_keep <- c("wanted_file", "n_threads")
     vars <- ls()
     to_remove <- setdiff(vars, to_keep)
-    suppressWarnings(rm(list = to_remove, envir = .GlobalEnv))
+    suppressWarnings(rm(list = r$to_remove, envir = .GlobalEnv))
 
     qs::qreadm(
-      file = wanted_file,
+      file = r$wanted_file,
       env = .GlobalEnv,
       nthreads = n_threads
     )

--- a/R/workspace_restore.R
+++ b/R/workspace_restore.R
@@ -38,7 +38,7 @@
 workspace_restore <- function(
   n_threads = 2,
   is_interactive = interactive()
-) { # styler: off
+) {
   assert_interactive(is_interactive)
   stopifnot(is.numeric(n_threads))
 
@@ -59,6 +59,123 @@ workspace_restore <- function(
     return(invisible())
   }
 
+  r <- restore_method(files)
+
+  cat2(
+    "Do you want to clear your environment or merge?",
+    symbol = red_todo
+  )
+
+  cm <- c("Clear", "Merge")
+  user_clear_or_merge <- cm[utils::menu(cm)]
+
+  if (user_clear_or_merge == "Clear") {
+    cat2(
+      "WARNING! Restoring will reset your global environment to '",
+      r$files_display[r$i],
+      "'. Continue?",
+      symbol = red_todo
+    )
+
+    user_response <- utils::menu(c("Yes", "No"))
+
+    if (user_response %in% c(0L, 2L)) {
+      cat2(
+        "Restore cancelled",
+        symbol = red_x
+      )
+
+      return(invisible())
+    }
+
+    # Clear all variables except wanted_file and n_threads
+    to_keep <- c("wanted_file", "n_threads")
+    vars <- ls()
+    to_remove <- setdiff(vars, to_keep)
+    suppressWarnings(rm(list = to_remove, envir = .GlobalEnv))
+
+    qs::qreadm(
+      file = wanted_file,
+      env = .GlobalEnv,
+      nthreads = n_threads
+    )
+  } else {
+    cat2(
+      "When merging do you want to prioritize the current environment or the
+      restore point? For more information check the docs; '?workspace_restore'",
+      symbol = red_todo
+    )
+
+    merge_options <- c("Current environment", "Restore point")
+    user_merge_options <- merge_options[utils::menu(merge_options)]
+
+    cat2(
+      "Continuing will modify your current workspace environment. Continue?",
+      symbol = red_x
+    )
+
+    user_response <- utils::menu(c("Yes", "No"))
+
+    if (user_response %in% c(0L, 2L)) {
+      cat2(
+        "Restore cancelled",
+        symbol = red_x
+      )
+
+      return(invisible())
+    }
+
+    # Save current env as a temp file
+    tmp_dir <- withr::local_tempdir()
+    tmp_ws <- workspace_save(
+      note = "tmp_merge_",
+      .dir = tmp_dir
+    )
+
+    # Based on the user's selection, load restore point without resetting for
+    # "restore point". for "current environment" load the restore point and then
+    # load the newly created restore point
+    to_keep <- c("wanted_file", "n_threads")
+    vars <- ls()
+    to_remove <- setdiff(vars, to_keep)
+    suppressWarnings(rm(list = to_remove, envir = .GlobalEnv))
+
+    if (user_merge_options == "Current environment") {
+      qs::qreadm(
+        file = r$wanted_file,
+        env = .GlobalEnv,
+        nthreads = n_threads
+      )
+
+      qs::qreadm(
+        file = tmp_ws,
+        env = .GlobalEnv,
+        nthreads = n_threads
+      )
+    } else {
+      qs::qreadm(
+        file = tmp_ws,
+        env = .GlobalEnv,
+        nthreads = n_threads
+      )
+
+      qs::qreadm(
+        file = r$wanted_file,
+        env = .GlobalEnv,
+        nthreads = n_threads
+      )
+    }
+  }
+
+  cat2(
+    "Restore complete",
+    symbol = green_check
+  )
+
+  return(invisible())
+}
+
+restore_method <- function(files) {
   cat2(
     "Would you like to use the latest or a specific restore point?",
     symbol = red_todo
@@ -100,40 +217,11 @@ workspace_restore <- function(
     wanted_file <- sorted_files[i]
   }
 
-  cat2(
-    "WARNING! Restoring will reset your global environment to '",
-    files_display[i],
-    "'. Continue?",
-    symbol = red_todo
+  l_return <- list(
+    wanted_file = wanted_file,
+    files_display = files_display,
+    i = i
   )
 
-  user_response <- utils::menu(c("Yes", "No"))
-
-  if (user_response %in% c(0L, 2L)) {
-    cat2(
-      "Restore cancelled",
-      symbol = red_x
-    )
-
-    return(invisible())
-  }
-
-  # Clear all variables except wanted_file and n_threads
-  to_keep <- c("wanted_file", "n_threads")
-  vars <- ls()
-  to_remove <- setdiff(vars, to_keep)
-  suppressWarnings(rm(list = to_remove, envir = .GlobalEnv))
-
-  qs::qreadm(
-    file = wanted_file,
-    env = .GlobalEnv,
-    nthreads = n_threads
-  )
-
-  cat2(
-    "Restore complete",
-    symbol = green_check
-  )
-
-  return(invisible())
+  return(l_return)
 }

--- a/R/workspace_save.R
+++ b/R/workspace_save.R
@@ -27,6 +27,8 @@
 #'
 #' @param note Character. Default `""`. An optional note to add to the restore
 #' point, providing additional context or information.
+#' @param .dir Character. Default `getOption("workspace.dir", "_workspace")`.
+#' Directory path to save workspace files.
 #' @param n_threads Integer. Default `2`. The number of threads to use for the
 #' saving process.
 #' @param is_interactive Logical. Default `interactive()`. This parameter is
@@ -35,7 +37,7 @@
 #'
 #' @family workspace functions
 #'
-#' @return Nothing.
+#' @return File path of the newly created workspace file, invisibly.
 #' @export
 #'
 #' @examples
@@ -48,17 +50,18 @@
 #' }
 workspace_save <- function(
   note = "",
+  .dir = "_workspace",
   n_threads = 2,
   is_interactive = interactive()
-) { # styler: off
+) {
   assert_interactive(is_interactive)
   stopifnot(is.numeric(n_threads))
 
   folder_name <- "_workspace"
 
   # Check if the folder exists
-  if (!file.exists(folder_name) || !file.info(folder_name)$isdir) {
-    dir.create(folder_name)
+  if (!file.exists(.dir) || !file.info(.dir)$isdir) {
+    dir.create(.dir)
 
     # Text file for more information
     text <- "The '_workspace' folder and the 'ws-{date/time}.qs' files are all
@@ -105,12 +108,14 @@ workspace_save <- function(
     )
   )
 
-  cat2(
-    "Restore point created: '",
-    file_name,
-    "'",
-    symbol = green_check
-  )
+  if (note != "tmp_merge_") {
+    cat2(
+      "Restore point created: '",
+      file_name,
+      "'",
+      symbol = green_check
+    )
+  }
 
-  return(invisible())
+  return(invisible(file_name))
 }

--- a/R/workspace_save.R
+++ b/R/workspace_save.R
@@ -50,7 +50,7 @@
 #' }
 workspace_save <- function(
   note = "",
-  .dir = "_workspace",
+  .dir = getOption("grkstyle.use_tabs", "_workspace"),
   n_threads = 2,
   is_interactive = interactive()
 ) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -185,10 +185,15 @@ d
 
 It's back! Woo! 💃
 
-## What this package does not do today
+## Contributing
 
-- Cleanup the `_workspace` folder
-- Allow the user to change the default location of `_workspace`
+Contributing is welcome! This package uses the [precommit framework](https://lorenzwalthert.github.io/precommit/index.html) and passing the precommit test for PRs is required.
+
+```r
+remotes::install_github("lorenzwalthert/precommit")
+precommit::install_precommit()
+precommit::use_precommit()
+```
 
 ## Recognitions
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,9 +16,10 @@ knitr::opts_chunk$set(
 # {workspace}
 
 <!-- badges: start -->
-[![CRAN status](https://www.r-pkg.org/badges/version/workspace)](https://CRAN.R-project.org/package=workspace)
 [![R-CMD-check](https://github.com/KoderKow/workspace/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/KoderKow/workspace/actions/workflows/R-CMD-check.yaml)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/KoderKow/workspace/main.svg)](https://results.pre-commit.ci/latest/github/KoderKow/workspace/main)
 [![Codecov test coverage](https://codecov.io/gh/KoderKow/workspace/branch/main/graph/badge.svg)](https://app.codecov.io/gh/KoderKow/workspace?branch=main)
+[![CRAN status](https://www.r-pkg.org/badges/version/workspace)](https://CRAN.R-project.org/package=workspace)
 <!-- badges: end -->
 
 Welcome to {workspace}, where magic happens! 🎇 This package aims to make your RStudio sessions more exciting and efficient by allowing you to effortlessly create and restore dev environments.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 
 <!-- badges: start -->
 
-[![CRAN
-status](https://www.r-pkg.org/badges/version/workspace)](https://CRAN.R-project.org/package=workspace)
 [![R-CMD-check](https://github.com/KoderKow/workspace/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/KoderKow/workspace/actions/workflows/R-CMD-check.yaml)
+[![pre-commit.ci
+status](https://results.pre-commit.ci/badge/github/KoderKow/workspace/main.svg)](https://results.pre-commit.ci/latest/github/KoderKow/workspace/main)
 [![Codecov test
 coverage](https://codecov.io/gh/KoderKow/workspace/branch/main/graph/badge.svg)](https://app.codecov.io/gh/KoderKow/workspace?branch=main)
+[![CRAN
+status](https://www.r-pkg.org/badges/version/workspace)](https://CRAN.R-project.org/package=workspace)
 <!-- badges: end -->
 
 Welcome to {workspace}, where magic happens! 🎇 This package aims to

--- a/README.md
+++ b/README.md
@@ -190,10 +190,17 @@ d
 
 It’s back! Woo! 💃
 
-## What this package does not do today
+## Contributing
 
-- Cleanup the `_workspace` folder
-- Allow the user to change the default location of `_workspace`
+Contributing is welcome! This package uses the [precommit
+framework](https://lorenzwalthert.github.io/precommit/index.html) and
+passing the precommit test for PRs is required.
+
+``` r
+remotes::install_github("lorenzwalthert/precommit")
+precommit::install_precommit()
+precommit::use_precommit()
+```
 
 ## Recognitions
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,6 +1,8 @@
-.gitignore’
+<U+2019>
+.gitignore<U+2019>
 aut
 BugReports
+ci
 CMD
 Codecov
 Config
@@ -11,7 +13,8 @@ dev
 dir
 github
 gitignore
-gitignore’
+gitignore<U+2019>
+gitignore<U+2019>
 gmail
 HH
 href
@@ -23,10 +26,12 @@ MERCHANTABILITY
 modularity
 NONINFRINGEMENT
 params
+pre
 qs
 qsimage
 Rbuildignore
-Rbuildignore’
+Rbuildignore<U+2019>
+Rbuildignore<U+2019>
 Recognitions
 restorepoint
 rmd
@@ -36,7 +41,8 @@ RStudio
 sublicense
 testthat
 withr
-workspace’
+workspace<U+2019>
+workspace<U+2019>
 ws
 YYYY
-’
+<U+2019>

--- a/man/workspace_restore.Rd
+++ b/man/workspace_restore.Rd
@@ -48,6 +48,32 @@ and displays a "Restore complete" message
 }
 }
 }
+\section{Restore method}{
+There are two ways to restore the environment
+\enumerate{
+\item \strong{Clear}
+\itemize{
+\item Wipe the environment clean and restore the workspace from the wanted
+file
+\item This option is best if you want to reproduce the wanted environment
+when it was saved
+}
+\item \strong{Merge}
+\itemize{
+\item Combines the current environment/workspace with the wanted file
+\item There are two merge styles
+\itemize{
+\item 1: \strong{Current environment}: When bringing in the workspace from the
+wanted file, it will prioritize the current environments variables
+if the same variable is used in both environments
+\item 2: \strong{Restore point}: When bringing in the workspace from the
+wanted file, it will prioritize the restore file's variables if the
+same variable is used in both environments
+}
+}
+}
+}
+
 \examples{
 \dontrun{
 # Initiate the restore process

--- a/man/workspace_save.Rd
+++ b/man/workspace_save.Rd
@@ -4,11 +4,19 @@
 \alias{workspace_save}
 \title{Create a restore point for the current development environment}
 \usage{
-workspace_save(note = "", n_threads = 2, is_interactive = interactive())
+workspace_save(
+  note = "",
+  .dir = "_workspace",
+  n_threads = 2,
+  is_interactive = interactive()
+)
 }
 \arguments{
 \item{note}{Character. Default \code{""}. An optional note to add to the restore
 point, providing additional context or information.}
+
+\item{.dir}{Character. Default \code{getOption("workspace.dir", "_workspace")}.
+Directory path to save workspace files.}
 
 \item{n_threads}{Integer. Default \code{2}. The number of threads to use for the
 saving process.}
@@ -18,7 +26,7 @@ used for package development purposes only, and it is recommended to avoid
 changing this setting.}
 }
 \value{
-Nothing.
+File path of the newly created workspace file, invisibly.
 }
 \description{
 This function creates a restore point for the current development environment

--- a/man/workspace_save.Rd
+++ b/man/workspace_save.Rd
@@ -6,7 +6,7 @@
 \usage{
 workspace_save(
   note = "",
-  .dir = "_workspace",
+  .dir = getOption("grkstyle.use_tabs", "_workspace"),
   n_threads = 2,
   is_interactive = interactive()
 )


### PR DESCRIPTION
- Added an option while restoring to merge the current workspace with another file's worksapce
- Improved user prompts to show that their environment will be cleared out while restoring
- Added a parameter to `workspace_save()` to control where workspace files are saved